### PR TITLE
Excluded post readings route from csrf filter

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -21,6 +21,7 @@ POST    /rooms/:roomId/measurements         controllers.MeasurementsController.a
 GET     /measurements/:measurementId        controllers.MeasurementsController.getMeasurementById(measurementId : Long)
 PUT     /measurements/active/:measurementId controllers.MeasurementsController.startMeasurement(measurementId : Long)
 DELETE  /measurements/active                controllers.MeasurementsController.stopMeasurement()
++ nocsrf
 POST    /measurements/active/readings       controllers.MeasurementsController.addReadings()
 DELETE  /measurements/:measurementId        controllers.MeasurementsController.removeMeasurement(measurementId: Long)
 GET     /streamMeasurements                 controllers.MeasurementsController.streamMeasurements


### PR DESCRIPTION
Excluded post readings route from csrf filter because it is not implemented in Flux-sensors and represents no security risk for this application